### PR TITLE
drop `clone` module in favor of `JSON.parse` & `JSON.stringify` combo for better performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # request-debug [![Build status](https://img.shields.io/travis/request/request-debug.svg?style=flat)](https://travis-ci.org/request/request-debug) [![npm package](http://img.shields.io/npm/v/request-debug.svg?style=flat)](https://www.npmjs.org/package/request-debug)
 
 This Node.js module provides an easy way to monitor HTTP(S) requests performed
-by the [`request` module](https://github.com/mikeal/request), and their
+by the [`request` module](https://github.com/request/request), and their
 responses from external servers.
 
 ## Usage
@@ -83,15 +83,15 @@ Unless you provide your own function as the second parameter to the
 following:
 
 ```js
-{ request: 
+{ request:
    { debugId: 1,
      uri: 'http://nylen.tv/digest.php',
      method: 'GET',
      headers: { host: 'nylen.tv' } } }
-{ auth: 
+{ auth:
    { debugId: 1,
      statusCode: 401,
-     headers: 
+     headers:
       { date: 'Mon, 20 Oct 2014 03:34:58 GMT',
         server: 'Apache/2.4.6 (Debian)',
         'x-powered-by': 'PHP/5.5.6-1',
@@ -101,16 +101,16 @@ following:
         connection: 'Keep-Alive',
         'content-type': 'text/html' },
      uri: 'http://nylen.tv/digest.php' } }
-{ request: 
+{ request:
    { debugId: 1,
      uri: 'http://nylen.tv/digest.php',
      method: 'GET',
-     headers: 
+     headers:
       { authorization: 'Digest username="admin", realm="Restricted area", nonce="544482e2556d9", uri="/digest.php", qop=auth, response="e833c7fa52e8d42fae3ca784b96dfd38", nc=00000001, cnonce="ab6ff3dd95a0449e990a6c8465a6bb26", opaque="cdce8a5c95a1427d74df7acbf41c9ce0"',
         host: 'nylen.tv' } } }
-{ response: 
+{ response:
    { debugId: 1,
-     headers: 
+     headers:
       { date: 'Mon, 20 Oct 2014 03:34:58 GMT',
         server: 'Apache/2.4.6 (Debian)',
         'x-powered-by': 'PHP/5.5.6-1',

--- a/index.js
+++ b/index.js
@@ -1,5 +1,3 @@
-var clone = require('clone');
-
 var debugId = 0;
 
 module.exports = exports = function(request, log) {
@@ -30,7 +28,7 @@ module.exports = exports = function(request, log) {
                         debugId : this._debugId,
                         uri     : this.uri.href,
                         method  : this.method,
-                        headers : clone(this.headers)
+                        headers : JSON.parse(JSON.stringify(this.headers))
                     };
                     if (this.body) {
                         data.body = this.body.toString('utf8');
@@ -45,7 +43,7 @@ module.exports = exports = function(request, log) {
                         // cannot get body since no callback specified
                         log('response', {
                             debugId    : this._debugId,
-                            headers    : clone(res.headers),
+                            headers    : JSON.parse(JSON.stringify(res.headers)),
                             statusCode : res.statusCode
                         }, this);
                     }
@@ -54,7 +52,7 @@ module.exports = exports = function(request, log) {
                     if (this.callback) {
                         log('response', {
                             debugId    : this._debugId,
-                            headers    : clone(res.headers),
+                            headers    : JSON.parse(JSON.stringify(res.headers)),
                             statusCode : res.statusCode,
                             body       : res.body
                         }, this);
@@ -65,7 +63,7 @@ module.exports = exports = function(request, log) {
                     log(type, {
                         debugId    : this._debugId,
                         statusCode : this.response.statusCode,
-                        headers    : clone(this.response.headers),
+                        headers    : JSON.parse(JSON.stringify(this.response.headers)),
                         uri        : this.uri.href
                     }, this);
                 });

--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+var clone = require('stringify-clone');
+
 var debugId = 0;
 
 module.exports = exports = function(request, log) {
@@ -28,7 +30,7 @@ module.exports = exports = function(request, log) {
                         debugId : this._debugId,
                         uri     : this.uri.href,
                         method  : this.method,
-                        headers : JSON.parse(JSON.stringify(this.headers))
+                        headers : clone(this.headers)
                     };
                     if (this.body) {
                         data.body = this.body.toString('utf8');
@@ -43,7 +45,7 @@ module.exports = exports = function(request, log) {
                         // cannot get body since no callback specified
                         log('response', {
                             debugId    : this._debugId,
-                            headers    : JSON.parse(JSON.stringify(res.headers)),
+                            headers    : clone(res.headers),
                             statusCode : res.statusCode
                         }, this);
                     }
@@ -52,7 +54,7 @@ module.exports = exports = function(request, log) {
                     if (this.callback) {
                         log('response', {
                             debugId    : this._debugId,
-                            headers    : JSON.parse(JSON.stringify(res.headers)),
+                            headers    : clone(res.headers),
                             statusCode : res.statusCode,
                             body       : res.body
                         }, this);
@@ -63,7 +65,7 @@ module.exports = exports = function(request, log) {
                     log(type, {
                         debugId    : this._debugId,
                         statusCode : this.response.statusCode,
-                        headers    : JSON.parse(JSON.stringify(this.response.headers)),
+                        headers    : clone(this.response.headers),
                         uri        : this.uri.href
                     }, this);
                 });

--- a/package.json
+++ b/package.json
@@ -23,13 +23,14 @@
     },
     "main"            : "index.js",
     "devDependencies" : {
-        "express"        : "~4.8.6",
-        "mocha"          : "~1.21.4",
-        "passport"       : "~0.2.0",
-        "passport-http"  : "~0.2.2",
-        "request"        : "~2.40.0",
-        "should"         : "~4.0.4",
-        "stringify-clone": "^1.0.0"
+        "express"       : "~4.8.6",
+        "mocha"         : "~1.21.4",
+        "passport"      : "~0.2.0",
+        "passport-http" : "~0.2.2",
+        "request"       : "~2.40.0",
+        "should"        : "~4.0.4"
     },
-    "dependencies" : {}
+    "dependencies" : {
+        "stringify-clone": "^1.0.0"
+    }
 }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,5 @@
         "request"       : "~2.40.0",
         "should"        : "~4.0.4"
     },
-    "dependencies" : {
-        "clone" : "~0.1.18"
-    }
+    "dependencies" : {}
 }

--- a/package.json
+++ b/package.json
@@ -23,12 +23,13 @@
     },
     "main"            : "index.js",
     "devDependencies" : {
-        "express"       : "~4.8.6",
-        "mocha"         : "~1.21.4",
-        "passport"      : "~0.2.0",
-        "passport-http" : "~0.2.2",
-        "request"       : "~2.40.0",
-        "should"        : "~4.0.4"
+        "express"        : "~4.8.6",
+        "mocha"          : "~1.21.4",
+        "passport"       : "~0.2.0",
+        "passport-http"  : "~0.2.2",
+        "request"        : "~2.40.0",
+        "should"         : "~4.0.4",
+        "stringify-clone": "^1.0.0"
     },
     "dependencies" : {}
 }


### PR DESCRIPTION
[benchmarks](https://github.com/ahmadnassri/node-clone-benchmark) show `JSON.stringify` to be faster and uses less memory

```
  JSON.stringify   x 40,423 ops/sec ±1.77% (87 runs sampled)
  clone            x 17,677 ops/sec ±2.36% (93 runs sampled)
```