### PR TITLE
Stringify response body in case it is an object

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,7 +56,7 @@ module.exports = exports = function(request, log) {
               debugId    : this._debugId,
               headers    : clone(res.headers),
               statusCode : res.statusCode,
-              body       : res.body
+              body       : JSON.stringify(res.body)
             }, this)
           }
 


### PR DESCRIPTION
`console.log({ errors: [{ exception: "GreedyLittleHandsException", message: "No pie for you!!" }] })`

Will output: 

`{ errors: [Object] }`

Which is not what I want. 

![Screenshot of pain point in log when debugging request](https://raw.githubusercontent.com/forestjohnsonilm/request-debug/forest-work-branch/pain.png)
