### PR TITLE
Include formdata on form multipart requests

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,6 +32,12 @@ module.exports = exports = function(request, log) {
             method  : this.method,
             headers : clone(this.headers)
           }
+          if (this._form) {
+            // getBuffer() was added in form-data 2.5.0
+            // But request still bundles form-data 2.3.2, so... monkey-patch
+            this._form.getBuffer = require('form-data').prototype.getBuffer;
+            data.formdata = this._form.getBuffer()
+          }
           if (this.body) {
             data.body = this.body.toString('utf8')
           }

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "should"        : "~4.0.4"
   },
   "dependencies" : {
+    "form-data": "2.5.0",
     "stringify-clone": "^1.0.0"
   }
 }


### PR DESCRIPTION
## Motivation

In a project recently, I was troubleshooting some failed form submissions with `request` and it was very useful for me to see the actual body of the multipart/form-data request. When [I asked on Stack Overflow](https://stackoverflow.com/q/57334503/190298) how to get the raw message body of the HTTP request, a few people suggested that I use this project (request-debug).

But until now, request-debug didn't actually show the body of multipart/form-data requests! So I added it.

## Safety

This adds a dependency on `form-data`. That doesn't seem unreasonable, because `request` is already bringing in a version of `form-data`. But it's bringing in a slightly older version without the very useful `getBuffer()` method, so this change just monkey-patches the useful code onto the old object. The ideal solution would be for `request` to update their dependency on `form-data` to bring in 2.5.0 or higher.

This inspects a property (`_form`) that is internal to `request`. If that is ever removed, request-debug would fail safe. But if it was changed to a different object (not a form-data object) that could cause request-debug to fail.

Basically, this should work just fine until the next major version of `form-data` is released, and possibly longer.